### PR TITLE
AMS-01S: Suboptimal Representation of Time Literals

### DIFF
--- a/contracts/AtlasMineStakerUpgradeable.sol
+++ b/contracts/AtlasMineStakerUpgradeable.sol
@@ -1012,7 +1012,7 @@ contract AtlasMineStakerUpgradeable is
     function _isAccrualWindow() internal view returns (bool inWindow) {
         require(accrualWindows.length > 0, "Accrual windows not set");
         /// time elapsed in day / hours
-        uint256 currentHour = (block.timestamp % 86_400) / 3_600;
+        uint256 currentHour = (block.timestamp % 1 days) / 1 hours;
 
         for (uint256 i = 0; i < accrualWindows.length - 1; i += 2) {
             if (currentHour >= accrualWindows[i] && currentHour < accrualWindows[i + 1]) {


### PR DESCRIPTION
_The linked time literals are sub-optimally represented as numeric values._

Fix time literals to use Solidity built-in representations.