### PR TITLE
AMS-01M: Inexistent Protection of Administrative Functions

### DIFF
--- a/contracts/AtlasMineStakerUpgradeable.sol
+++ b/contracts/AtlasMineStakerUpgradeable.sol
@@ -538,7 +538,7 @@ contract AtlasMineStakerUpgradeable is
      *         If unlockAll is set to true in the Atlas Mine, this can withdraw
      *         all stake.
      */
-    function unstakeAllFromMine() external override onlyOwner {
+    function unstakeAllFromMine() external override onlyOwner whenNotAccruing {
         uint256 totalStakes = stakes.length;
         for (uint256 i = nextActiveStake; i < totalStakes; i++) {
             Stake memory s = stakes[i];

--- a/test/staker/AtlasMineStaker.ts
+++ b/test/staker/AtlasMineStaker.ts
@@ -1754,6 +1754,15 @@ describe("Atlas Mine Staking (Pepe Pool)", () => {
                 );
             });
 
+            it("does not allow an owner to unstake all possible stake during an accrual window", async () => {
+                const { admin, staker } = ctx;
+
+                // Set accrual window for every hr
+                await staker.connect(admin).setAccrualWindows([0, 24]);
+
+                await expect(staker.connect(admin).unstakeAllFromMine()).to.be.revertedWith("In accrual window");
+            });
+
             it("allows an owner to unstake all possible stake", async () => {
                 const {
                     admin,
@@ -1783,6 +1792,8 @@ describe("Atlas Mine Staking (Pepe Pool)", () => {
                 expectRoundedEqual(await magic.balanceOf(staker.address), 0);
 
                 await accrue(staker);
+                await rollToDepositWindow();
+
                 await staker.connect(admin).unstakeAllFromMine();
 
                 // Staker should now hold all total rewards plus all unstaked deposits (10 unites)


### PR DESCRIPTION
_The administrative unstaking functions are not properly guarded against execution during an accrual window._

Added the `whenNotAccuring` modifier to `unstakeAllFromMine` as well as a test that verifies proper behavior.